### PR TITLE
ISSUE-1: esmero-cantaloupe is not serving PNG via graphicsmagic processor

### DIFF
--- a/esmero-cantaloupe/Dockerfile
+++ b/esmero-cantaloupe/Dockerfile
@@ -22,8 +22,8 @@ RUN apk add --update ttf-dejavu && rm -rf /var/cache/apk/*
 
 ENV CANTALOUPE_VERSION 4.0.3
 ENV PKGNAME=graphicsmagick
-# 1.3.30 (Released June 23, 2018)
-ENV PKGVER=1.3.30
+# 1.3.33 (Released July 20, 2019)
+ENV PKGVER=1.3.33
 # Uses 50% of the memory of 16. Use 16 if dealing with 48/64 bit pixels color
 ENV QUANTUMDEPTH=8
 ENV PKGSOURCE=http://downloads.sourceforge.net/$PKGNAME/$PKGNAME/$PKGVER/GraphicsMagick-$PKGVER.tar.lz
@@ -49,6 +49,7 @@ RUN apk add --no-cache --update g++ \
                      jasper-dev \
                      libx11-dev \
                      libpng-dev \
+                     libpng \
                      libtool \
                      jasper-dev \
                      bzip2-dev \
@@ -114,7 +115,7 @@ RUN curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CA
  && mkdir -p /etc/cantaloupe \
  && cp /usr/local/cantaloupe/deps/Linux-x86-64/lib/* /usr/lib/. 
 # upcoming docker releases: use --chown=cantaloupe
-COPY cantaloupe.properties /etc/cantaloupe/cantaloupe.properties 
+COPY cantaloupeconfig/cantaloupe.properties /etc/cantaloupe/cantaloupe.properties 
 RUN mkdir -p /var/log/cantaloupe \
  && mkdir -p /var/cache/cantaloupe \
  && chown -R cantaloupe /var/log/cantaloupe \


### PR DESCRIPTION
### What's new?
I added extra libpng library to the installed apk packages
Updated GraphicsMagick to 1.3.33
Changed COPY path in Dockerfile because that was giving me errors. Since `cantaloupe.properties` is inside a directory

### What's still broken?
Well, yes, PNG issue is still not fixed. 

From the install logs (truncated):
```
Option            Configure option      	Configured value
-----------------------------------------------------------------
PNG               --with-png=yes          	yes (-lpng16)
```

And this is still what happens once GraphicsMagick is installed. Missing -lpng16 in LIBS at the bottom.
```
bash-4.4$ gm version
GraphicsMagick 1.3.33 2019-07-20 Q8 http://www.GraphicsMagick.org/
Copyright (C) 2002-2019 GraphicsMagick Group.
Additional copyrights and licenses apply to this software.
See http://www.GraphicsMagick.org/www/Copyright.html for details.

Feature Support:
  Native Thread Safe       yes
  Large Files (> 32 bit)   yes
  Large Memory (> 32 bit)  yes
  BZIP                     yes
  DPS                      no
  FlashPix                 no
  FreeType                 yes
  Ghostscript (Library)    no
  JBIG                     no
  JPEG-2000                yes
  JPEG                     yes
  Little CMS               yes
  Loadable Modules         yes
  Solaris mtmalloc         no
  OpenMP                   yes (201511 "4.5")
  PNG                      yes
  TIFF                     yes
  TRIO                     no
  Solaris umem             no
  WebP                     no
  WMF                      yes
  X11                      yes
  XML                      yes
  ZLIB                     yes

Host type: x86_64-pc-linux-musl

Configured using the command:
  ./configure  '--build=' '--host=' '--prefix=/usr' '--sysconfdir=/etc' '--enable-magick-compat' '--mandir=/usr/share/man' '--infodir=/usr/share/info' '--localstatedir=/var' '--enable-shared' '--disable-static' '--with-gslib' '--with-modules=yes' '--with-threads' '--with-webp=yes' '--with-tiff=yes' '--with-jpeg=yes' '--with-jp2=yes' '--with-png=yes' '--with-xml=yes' '--with-wmf=yes' '--with-gs-font-dir=/usr/share/fonts/Type1' '--with-quantum-depth=8' 'build_alias=' 'host_alias='

Final Build Parameters:
  CC       = gcc
  CFLAGS   = -fopenmp -g -O2 -Wall
  CPPFLAGS = -I/usr/include/freetype2 -I/usr/include/libxml2
  CXX      = g++
  CXXFLAGS = 
  LDFLAGS  = 
  LIBS     = -llcms2 -lfreetype -lX11 -lbz2 -lz -lltdl -lm -lpthread
```

The library is definitely installed. Not sure if it's linked/compiled incorrectly but in the install logs, it seems to be correct.
