### PR TITLE
ISSUE-8:Bump Cantaloupe to 4.1.5

### DIFF
--- a/esmero-cantaloupe/Dockerfile
+++ b/esmero-cantaloupe/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:13-alpine3.9
 
 ENV LANG en_US.UTF-8
 
@@ -8,22 +8,21 @@ ENV LANG en_US.UTF-8
 RUN apk add --update ttf-dejavu && rm -rf /var/cache/apk/*
 
 # Cantaloupe docker starter script
-
+# https://github.com/cantaloupe-project/cantaloupe/releases/tag/v4.1.5
 # Build and run: 
 # $ sudo docker build -t esmero-cantaloupe .
 # $ sudo docker run -d --rm -p 8183:8182 -v ./cantaloupeconfig:/etc/cantaloupe --name esmero-cantaloupe esmero-cantaloupe
 
 # Publish new tag -- PRIVATE
-# $docker login (user diegopino)
-# $ docker docker build -t esmero/cantaloupe-s3:4.0.3
-# $ docker push esmero/cantaloupe-s3:4.0.3
+# $docker login (user diegopino) use your own name folks!
+# $ docker docker build -t esmero/cantaloupe-s3:4.1.5
+# $ docker push esmero/cantaloupe-s3:4.1.5
+# See upgrading from 4.0.3 to 4.1.5 https://github.com/cantaloupe-project/cantaloupe/blob/develop/UPGRADING.md#40x--41
 
-#docker push esmero/cantaloupe-s3:4.0.
-
-ENV CANTALOUPE_VERSION 4.0.3
+ENV CANTALOUPE_VERSION 4.1.5
 ENV PKGNAME=graphicsmagick
-# 1.3.30 (Released June 23, 2018)
-ENV PKGVER=1.3.30
+# 1.3.34 (Released Dec 20, 2019)
+ENV PKGVER=1.3.34
 # Uses 50% of the memory of 16. Use 16 if dealing with 48/64 bit pixels color
 ENV QUANTUMDEPTH=8
 ENV PKGSOURCE=http://downloads.sourceforge.net/$PKGNAME/$PKGNAME/$PKGVER/GraphicsMagick-$PKGVER.tar.lz
@@ -73,8 +72,7 @@ RUN wget $PKGSOURCE && \
       --localstatedir=/var \
       --enable-shared \
       --disable-static \
-      --with-gslib \
-      --with-modules=yes \
+      --with-modules \
       --with-threads \
       --with-webp=yes \
       --with-tiff=yes \
@@ -83,6 +81,7 @@ RUN wget $PKGSOURCE && \
       --with-png=yes \
       --with-xml=yes \
       --with-wmf=yes \
+			--with-ttf \
       --with-gs-font-dir=/usr/share/fonts/Type1 \
       --with-quantum-depth=$QUANTUMDEPTH && \
     make && \

--- a/esmero-cantaloupe/cantaloupe.properties
+++ b/esmero-cantaloupe/cantaloupe.properties
@@ -53,6 +53,9 @@ slash_substitute =
 # response. Set to 0 for no maximum.
 max_pixels = 400000000
 
+# Maximum scale to allow (1.0 = full scale; 0 = no maximum).
+max_scale = 1.0
+
 # Errors will also be logged to the error log (if enabled).
 print_stack_trace_on_error_pages = true
 
@@ -76,11 +79,6 @@ delegate_script.cache.enabled = false
 ###########################################################################
 # ENDPOINTS
 ###########################################################################
-
-# !! Configures HTTP Basic authentication in all public endpoints.
-endpoint.public.auth.basic.enabled = false
-endpoint.public.auth.basic.username = myself
-endpoint.public.auth.basic.secret = mypassword
 
 # Enables the IIIF Image API 1.x endpoint, at /iiif/1.
 endpoint.iiif.1.enabled = false
@@ -129,24 +127,79 @@ source.static = S3Source
 source.delegate = false
 
 #----------------------------------------
+# FilesystemSource
+#----------------------------------------
+
+# How to look up files. Allowed values are `BasicLookupStrategy` and
+# `ScriptLookupStrategy`. ScriptLookupStrategy uses the delegate script for
+# dynamic lookups; see the user manual.
+FilesystemSource.lookup_strategy = BasicLookupStrategy
+
+# Server-side path that will be prefixed to the identifier in the URL.
+# Trailing slash is important!
+FilesystemSource.BasicLookupStrategy.path_prefix = /home/myself/images/
+
+# Server-side path or extension that will be suffixed to the identifier in
+# the URL.
+FilesystemSource.BasicLookupStrategy.path_suffix =
+
+#----------------------------------------
+# HttpSource
+#----------------------------------------
+
+# Trusts insecure certificates and cipher suites.
+HttpSource.allow_insecure = false
+
+# Request timeout in seconds.
+HttpSource.request_timeout =
+
+# Tells HttpSource how to look up resources. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses a delegate method for dynamic lookups; see the user manual.
+HttpSource.lookup_strategy = BasicLookupStrategy
+
+# URL that will be prefixed to the identifier in the request URL.
+# Trailing slash is important!
+HttpSource.BasicLookupStrategy.url_prefix = http://localhost/images/
+
+# Path, extension, query string, etc. that will be suffixed to the
+# identifier in the request URL.
+HttpSource.BasicLookupStrategy.url_suffix =
+
+# Enables access to resources that require HTTP Basic authentication.
+HttpSource.BasicLookupStrategy.auth.basic.username =
+HttpSource.BasicLookupStrategy.auth.basic.secret =
+
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+HttpSource.chunking.enabled = true
+
+# Chunk size.
+HttpSource.chunking.chunk_size = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+HttpSource.chunking.cache.enabled = true
+
+# Max per-request chunk cache size.
+HttpSource.chunking.cache.max_size = 5M
+
+#----------------------------------------
 # S3Source
 #----------------------------------------
 
 # !! Endpoint URI.
 # For AWS endpoints, see:
 # https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-S3Source.endpoint = s3.amazonaws.com
+S3Source.endpoint = 
 
 # !! Credentials for your AWS account.
 # See: http://aws.amazon.com/security-credentials
 # Note that this info can be obtained from elsewhere rather than setting
 # it here; see the user manual.
-S3Source.access_key_id = YOURID
-S3Source.secret_key = YOURSECRET
 
-# !! Maximum number of concurrent HTTP connections to AWS. Leave blank to
-# use the default.
-S3Source.max_connections =
+S3Source.access_key_id = 
+S3Source.secret_key = 
 
 # Tells S3Source how to look up objects. Allowed values are
 # `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
@@ -154,15 +207,28 @@ S3Source.max_connections =
 S3Source.lookup_strategy = BasicLookupStrategy
 
 # !! Name of the bucket containing images to be served.
-S3Source.BasicLookupStrategy.bucket.name = esmero
+S3Source.BasicLookupStrategy.bucket.name = 
 
 # Path within the bucket that will be prefixed to the identifier in the URL.
 # Trailing slash is important!
-S3Source.BasicLookupStrategy.path_prefix = archipelago-test/media/
+S3Source.BasicLookupStrategy.path_prefix = /
 
 # Path or extension that will be suffixed to the identifier in the URL.
 S3Source.BasicLookupStrategy.path_suffix =
 
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+S3Source.chunking.enabled = true
+
+# Chunk size.
+S3Source.chunking.chunk_size = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+S3Source.chunking.cache.enabled = true
+
+# Max per-request chunk cache size.
+S3Source.chunking.cache.max_size = 5M
 
 ###########################################################################
 # PROCESSORS
@@ -172,30 +238,37 @@ S3Source.BasicLookupStrategy.path_suffix =
 # Processor Selection
 #----------------------------------------
 
+# * If set to `AutomaticSelectionStrategy`, a "best" available processor
+#   will be selected per-request based on formats and installed
+#   dependencies.
+# * If set to `ManualSelectionStrategy`, a processor will be chosen based
+#   on the rest of the keys in this section.
+processor.selection_strategy = ManualSelectionStrategy
+
+
 # Image processors to use for various source formats. Available values are
 # `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
-# `KakaduDemoProcessor`, `≈`, `OpenJpegProcessor`,
+# `KakaduDemoProcessor`, `KakaduNativeProcessor`, `OpenJpegProcessor`,
 # `JaiProcessor`, `PdfBoxProcessor`, and `FfmpegProcessor`.
 
 # These extension-specific definitions are optional.
-processor.avi = FfmpegProcessor
-processor.bmp =
-processor.dcm = GraphicsMagickProcessor
-processor.flv = FfmpegProcessor
-processor.gif =
-processor.jp2 = KakaduNativeProcessor
-processor.jpg = Java2dProcessor
-processor.mov = FfmpegProcessor
-processor.mp4 = FfmpegProcessor
-processor.mpg = FfmpegProcessor
-processor.pdf = GraphicsMagickProcessor
-processor.png = GraphicsMagickProcessor
-processor.tif = Java2dProcessor
-processor.webm = FfmpegProcessor
-processor.webp = ImageMagickProcessor
+processor.ManualSelectionStrategy.avi = FfmpegProcessor
+processor.ManualSelectionStrategy.bmp =
+processor.ManualSelectionStrategy.dcm = GraphicsMagickProcessor
+processor.ManualSelectionStrategy.flv = FfmpegProcessor
+processor.ManualSelectionStrategy.gif =
+processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
+processor.ManualSelectionStrategy.jpg = TurboJpegProcessor
+processor.ManualSelectionStrategy.mov = FfmpegProcessor
+processor.ManualSelectionStrategy.mp4 = FfmpegProcessor
+processor.ManualSelectionStrategy.mpg = FfmpegProcessor
+processor.ManualSelectionStrategy.pdf = PdfBoxProcessor
+processor.ManualSelectionStrategy.png = Java2dProcessor
+processor.ManualSelectionStrategy.tif = Java2dProcessor
+processor.ManualSelectionStrategy.webm = FfmpegProcessor
 
 # Fall back to this processor for any formats not assigned above.
-processor.fallback = Java2dProcessor
+processor.ManualSelectionStrategy.fallback = Java2dProcessor
 
 #----------------------------------------
 # Global Processor Configuration
@@ -219,10 +292,6 @@ processor.fallback_retrieval_strategy = CacheStrategy
 
 # Resolution of vector rasterization (of e.g. PDFs) at a scale of 1.
 processor.dpi = 150
-
-# Expands contrast to utilize available dynamic range. This usually requires
-# the whole source image to be read into memory, so it can be inefficient.
-processor.normalize = false
 
 # Color of the background when an image is rotated or alpha-flattened, for
 # output formats that don't support transparency.
@@ -363,7 +432,7 @@ cache.server.info.enabled = true
 # missing, all cached information relating to it (if any) will be deleted.
 # (This is effectively always false when cache.server.resolve_first is also
 # false.)
-cache.server.purge_missing = false
+cache.server.purge_missing = true
 
 # If true, the source image will be confirmed to exist before a cached copy
 # is returned. If false, the cached copy will be returned without checking.
@@ -626,3 +695,5 @@ log.access.SyslogAppender.enabled = false
 log.access.SyslogAppender.host =
 log.access.SyslogAppender.port = 514
 log.access.SyslogAppender.facility = LOCAL0
+processor.webp =
+processor.ManualSelectionStrategy.webp=


### PR DESCRIPTION
See #8 

Includes also a newer `graphicsmagic` and i moved cantaloupe properties into same root as the docker file. No more copying things around when testing.

This wil become esmero/cantaloupe-s3:4.1.5

Cheers