### PR TITLE
Fix iconv issue

### DIFF
--- a/esmero-catmandu/Dockerfile
+++ b/esmero-catmandu/Dockerfile
@@ -1,0 +1,50 @@
+FROM alpine
+
+RUN apk update && apk upgrade && apk add curl perl perl-dev make gcc build-base wget gnupg alpine-sdk 
+RUN set -eux; \
+  \
+  apk add --no-cache --virtual .build-deps \
+    coreutils \
+    zlib-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libzip-dev \
+    expat-dev \
+    openssl-dev \
+      # Equivalent of build essentials
+    alpine-sdk 
+
+# Tools we want to keep
+RUN apk -U add --no-cache \
+      bash \
+      git openssh \
+      wget \
+      file \
+      curl \
+      nano \
+      && \
+      rm -rf /var/lib/apt/lists/* && \
+      rm /var/cache/apk/*
+
+RUN curl -LO https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm \
+    && chmod +x cpanm \
+    && ./cpanm App::cpanminus \
+    && rm -fr ./cpanm /root/.cpanm
+
+ENV PERL_CPANM_OPT --verbose --mirror https://cpan.metacpan.org --mirror-only
+RUN cpanm Digest::SHA Module::Signature inc::latest && rm -rf ~/.cpanm
+#ENV PERL_CPANM_OPT $PERL_CPANM_OPT --verify
+ENV PERL_CPANM_OPT $PERL_CPANM_OPT
+
+RUN cpanm Module::Runtime  
+RUN cpanm Moo  
+RUN cpanm Pod::Coverage Role::Tiny     
+RUN cpanm Module::Runtime Sub::Install YAML namespace::autoclean namespace::clean
+RUN cpanm XML::LibXML XML::XPath
+RUN cpanm Catmandu
+RUN cpanm Catmandu::OAI
+
+# Change to bash since our folks like bash
+SHELL ["/bin/bash", "-c"]
+WORKDIR /home/catmandu
+VOLUME ["/home/catmandu"]

--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -88,7 +88,7 @@ RUN { \
 		echo 'max_execution_time = 600'; \
 		echo 'log_errors = On'; \
 		echo 'error_log = /proc/self/fd/2'; \
-	} > /etc/php/php-cli.ini
+	} > /usr/local/etc/php/php-cli.ini
 	
 
 # Tools we want to keep

--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -66,7 +66,7 @@ RUN { \
 
 RUN { \
 		echo 'upload_max_filesize = 512M'; \
-    echo 'zend.enable_gc = On;' \
+    		echo 'zend.enable_gc = On;' \
 		echo 'post_max_size = 513M'; \
 		echo 'memory_limit = 512M'; \
 		echo 'max_execution_time = 300'; \
@@ -79,6 +79,17 @@ RUN { \
 		echo 'php_admin_flag[log_errors] = on'; \
 		echo 'catch_workers_output = yes'; \
 	} >> /usr/local/etc/php-fpm.d/www.conf
+
+RUN { \
+		echo 'upload_max_filesize = 512M'; \
+    		echo 'zend.enable_gc = On;' \
+		echo 'post_max_size = 513M'; \
+		echo 'memory_limit = -1'; \
+		echo 'max_execution_time = 600'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /proc/self/fd/2'; \
+	} > /etc/php/php-cli.ini
+	
 
 # Tools we want to keep
 RUN apk -U add --no-cache \
@@ -100,6 +111,9 @@ RUN apk -U add --no-cache \
 		&& \
 		rm -rf /var/lib/apt/lists/* && \
 		rm /var/cache/apk/*
+
+RUN apk add gnu-libiconv --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 # Installation of Composer
 RUN cd /usr/src && curl -sS http://getcomposer.org/installer | php


### PR DESCRIPTION
While producing PDFs inline i got this error Error generating document: Failed to generate PDF: iconv(): Wrong charset, conversion from `UTF-8' to `UTF-8//IGNORE' is not allowed which is related to missing encoding in the system

Also add the -1 to php cli mem limit. About time...