### PR TITLE
ISSUE:17 Add Env Arguments and Bump graphicsmagick version to 1.3.35 +  esmero/esmero-cantaloupe:4.1.6RC1

### DIFF
--- a/esmero-cantaloupe/Dockerfile
+++ b/esmero-cantaloupe/Dockerfile
@@ -4,6 +4,7 @@ ENV LANG en_US.UTF-8
 
 # JRE fails to load fonts if there are no standard fonts in the image; This breaks Cantaloups /admin endpoint
 # see https://github.com/docker-library/openjdk/issues/73#issuecomment-207816707
+# Also make sure you setup temp_pathname in cantaloupe.properties to a safe/stable place since Classes are cached there too.
 
 RUN apk add --update ttf-dejavu && rm -rf /var/cache/apk/*
 
@@ -21,8 +22,8 @@ RUN apk add --update ttf-dejavu && rm -rf /var/cache/apk/*
 
 ENV CANTALOUPE_VERSION 4.1.6
 ENV PKGNAME=graphicsmagick
-# 1.3.34 (Released Dec 20, 2019)
-ENV PKGVER=1.3.34
+# 1.3.35 (Released Febr 23, 2020)
+ENV PKGVER=1.3.35
 # Uses 50% of the memory of 16. Use 16 if dealing with 48/64 bit pixels color
 ENV QUANTUMDEPTH=8
 ENV PKGSOURCE=http://downloads.sourceforge.net/$PKGNAME/$PKGNAME/$PKGVER/GraphicsMagick-$PKGVER.tar.lz
@@ -100,6 +101,7 @@ RUN wget $PKGSOURCE && \
 
 RUN adduser -S cantaloupe
 RUN apk add --update --no-cache ffmpeg
+RUN apk add --update --no-cache libjpeg-turbo libjpeg-turbo-utils
 
 # Cantaloupe
 WORKDIR /tmp
@@ -121,5 +123,13 @@ RUN mkdir -p /var/log/cantaloupe \
  && chown -R cantaloupe /etc/cantaloupe
 
 USER cantaloupe 
+
+ARG XMX=2g
+ARG XMS=256m
+
+ENV XMS=${XMS}
+ENV XMX=${XMX}
+
+
 VOLUME ["/var/log/cantaloupe", "/var/cache/cantaloupe"]
-CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe/cantaloupe.properties -Xmx2g -jar /usr/local/cantaloupe/cantaloupe-$CANTALOUPE_VERSION.war"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe/cantaloupe.properties -Xms${XMS} -Xmx${XMX} -jar /usr/local/cantaloupe/cantaloupe-$CANTALOUPE_VERSION.war"]

--- a/esmero-cantaloupe/README.md
+++ b/esmero-cantaloupe/README.md
@@ -1,6 +1,6 @@
 ##  Esmero-cantaloupe IIIF Cantaloupe container
 
-Cantaloupe 4.03 Docker Image with Graphicsmagic and ffmpeg processors for the Archipelago Project
+Cantaloupe 4.16 Docker Image with Graphicsmagic, TurboJpeg and ffmpeg processors for the Archipelago Project
 
 ### Building the image
 ```SHELL
@@ -44,8 +44,15 @@ http://localhost:8183/iiif/2/esmero_test_video_by_diego.m4v/full/full/0/default.
 ffmpeg
 GraphicsMagic
 pdfbox
+TurboJpeg
 Kakadu Native processor
 S3 enabled
 Admin interface is enabled
-
 http://localhost:8183/admin
+
+Allows also ENV to be passed via e.g a docker-compose.yml
+Available ones are JavaVM Arguments
+XMX: 2gb (default)
+XMS: 256m (default)
+
+


### PR DESCRIPTION
See #17 

This allows XMX and XMS to be set on a docker-compose file as environment variables

I also pushed a new tag for the container:

`esmero/esmero-cantaloupe:4.1.6RC1` that matches this version can be used inmeditally

If someone wants to test, the change in the corresponding part for our archipelago-deployment the [docker-compose.yml](https://github.com/esmero/archipelago-deployment/blob/8.x-1.0-beta3/docker-compose-nginx.yml#L67) file is
```YML
iiif:
    container_name: esmero-cantaloupe
    image: "esmero/cantaloupe-s3:4.1.6RC1"
    restart: always
    environment:
      XMX: 4g
      XMS: 2g
    ports:
      - "8183:8182"
    networks:
      - host-net
      - esmero-net
    volumes:
      - ${PWD}/persistent/iiifconfig:/etc/cantaloupe
      - ${PWD}/persistent/iiifcache:/var/cache/cantaloupe
```

In this case giving initial 2 GBytes that can grow until 4Ggbytes. If none provided defaults  to 256m initial and 2G max.