### PR TITLE
ISSUE-21: esmero-php gets a proper Patch binary and WACZ

### DIFF
--- a/esmero-cantaloupe/Dockerfile
+++ b/esmero-cantaloupe/Dockerfile
@@ -9,18 +9,18 @@ ENV LANG en_US.UTF-8
 RUN apk add --update ttf-dejavu && rm -rf /var/cache/apk/*
 
 # Cantaloupe docker starter script
-# https://github.com/cantaloupe-project/cantaloupe/releases/tag/v4.1.6
+# https://github.com/cantaloupe-project/cantaloupe/releases/tag/v4.1.7
 # Build and run: 
 # $ sudo docker build -t esmero-cantaloupe .
 # $ sudo docker run -d --rm -p 8183:8182 -v ./cantaloupeconfig:/etc/cantaloupe --name esmero-cantaloupe esmero-cantaloupe
 
 # Publish new tag -- PRIVATE
 # $ docker login (user diegopino) use your own name folks!
-# $ docker build . -t esmero/cantaloupe-s3:4.1.6
-# $ docker push esmero/cantaloupe-s3:4.1.6
-# If moving from Archipelago beta1 to beta3, see upgrading from 4.0.3 to 4.1.6 https://github.com/cantaloupe-project/cantaloupe/blob/develop/UPGRADING.md#40x--41
+# $ docker build . -t esmero/cantaloupe-s3:4.1.7
+# $ docker push esmero/cantaloupe-s3:4.1.7
+# If moving from Archipelago beta1 to beta3, see upgrading from 4.0.3 to 4.1.7 https://github.com/cantaloupe-project/cantaloupe/blob/develop/UPGRADING.md#40x--41
 
-ENV CANTALOUPE_VERSION 4.1.6
+ENV CANTALOUPE_VERSION 4.1.7
 ENV PKGNAME=graphicsmagick
 # 1.3.35 (Released Febr 23, 2020)
 ENV PKGVER=1.3.35

--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -52,7 +52,7 @@ RUN set -eux; \
 	\
 	apk add --virtual .drupal-phpexts-rundeps $runDeps; \
 	docker-php-ext-enable --ini-name 20-imagick.ini imagick; \
-	apk del .build-deps
+        apk del .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -110,7 +110,6 @@ RUN apk -U add --no-cache \
 		tesseract-ocr-data-spa \
 		exiftool \
 		py3-setuptools \
-		py3-pip \
 		&& \
 		rm -rf /var/lib/apt/lists/* && \
 		rm /var/cache/apk/*
@@ -134,13 +133,21 @@ RUN cd /usr/src && wget https://github.com/openpreserve/fido/archive/v1.4.0.zip 
 RUN cd /usr/src/fido-1.4.0 && ./setup.py install
 
 # Install WACZ
+RUN set -eux; \
+        apk add --no-cache --virtual .build-deps-py \
+                 gcc \
+		 python3-dev \
+		 py3-pip \
+                 linux-headers \
+                 musl-dev \
+                 && \
+		 git clone https://github.com/webrecorder/wacz-format.git /usr/local/src/wacz && \
+                 cd /usr/local/src/wacz/ && git checkout master && \
+                 cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install \
+                 && apk del .build-deps-py
 
-RUN git clone https://github.com/webrecorder/wacz-format.git /usr/local/src/wacz
-RUN cd /usr/local/src/wacz/ && git checkout master
-RUN cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install
-
-#Clean up sources
-RUN rm -rf /usr/local/src/*
+#Clean up sources, we need to keep drush one
+RUN rm -rf /usr/local/src/wacz
 
 # Change to bash since our folks like bash
 SHELL ["/bin/bash", "-c"]

--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -8,7 +8,6 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		coreutils \
                 zlib-dev \
-		patch \
 		libxml2-dev \
 		libxslt-dev \
 		freetype-dev \
@@ -95,6 +94,7 @@ RUN { \
 # Tools we want to keep
 RUN apk -U add --no-cache \
 		bash \
+		patch \
 		git openssh \
 		wget \
 		imagemagick \
@@ -109,6 +109,8 @@ RUN apk -U add --no-cache \
 		tesseract-ocr-data-ita \
 		tesseract-ocr-data-spa \
 		exiftool \
+		py3-setuptools \
+		py3-pip \
 		&& \
 		rm -rf /var/lib/apt/lists/* && \
 		rm /var/cache/apk/*
@@ -118,14 +120,13 @@ ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 # Installation of Composer
 RUN cd /usr/src && curl -sS http://getcomposer.org/installer | php
-RUN cd /usr/src && mv composer.phar /usr/bin/composer
+RUN cd /usr/src && mv composer.phar /usr/bin/composer && composer self-update && composer self-update --2
 
 # Installation of drush
 RUN git clone https://github.com/drush-ops/drush.git /usr/local/src/drush 
 RUN cd /usr/local/src/drush && git checkout 10.3.6
 RUN ln -s /usr/local/src/drush/drush /usr/bin/drush
 RUN cd /usr/local/src/drush && composer update && composer install
-RUN cd /usr/src && curl https://drupalconsole.com/installer -L -o drupal.phar && mv drupal.phar /usr/local/bin/drupal
 
 # Install Fido 
 RUN cd /usr/src && wget https://github.com/openpreserve/fido/archive/v1.4.0.zip && unzip v1.4.0.zip \
@@ -136,7 +137,7 @@ RUN cd /usr/src/fido-1.4.0 && ./setup.py install
 
 RUN git clone https://github.com/webrecorder/wacz-format.git /usr/local/src/wacz
 RUN cd /usr/local/src/wacz/ && git checkout master
-RUN cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && ./setup.py install
+RUN cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install
 
 #Clean up sources
 RUN rm -rf /usr/local/src/*

--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.3-fpm-alpine
+FROM php:7.4.9-fpm-alpine3.12
 
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
@@ -24,9 +24,8 @@ RUN set -eux; \
 	; \
 	\
 	docker-php-ext-configure gd \
-		--with-freetype-dir=/usr/include \
-		--with-jpeg-dir=/usr/include \
-		--with-png-dir=/usr/include \
+		--with-freetype=/usr/include \
+		--with-jpeg=/usr/include \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \
@@ -49,9 +48,11 @@ RUN set -eux; \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	pecl install imagick; \
+        pecl install apcu; \
 	\
 	apk add --virtual .drupal-phpexts-rundeps $runDeps; \
-	docker-php-ext-enable --ini-name 20-imagick.ini imagick; \
+	docker-php-ext-enable imagick; \
+        docker-php-ext-enable apcu; \
         apk del .build-deps
 
 # set recommended PHP.ini settings
@@ -143,8 +144,7 @@ RUN set -eux; \
                  && \
 		 git clone https://github.com/webrecorder/wacz-format.git /usr/local/src/wacz && \
                  cd /usr/local/src/wacz/ && git checkout master && \
-                 cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install \
-                 && apk del .build-deps-py
+                 cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install
 
 #Clean up sources, we need to keep drush one
 RUN rm -rf /usr/local/src/wacz

--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -7,7 +7,8 @@ RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		coreutils \
-    zlib-dev \
+                zlib-dev \
+		patch \
 		libxml2-dev \
 		libxslt-dev \
 		freetype-dev \
@@ -121,7 +122,7 @@ RUN cd /usr/src && mv composer.phar /usr/bin/composer
 
 # Installation of drush
 RUN git clone https://github.com/drush-ops/drush.git /usr/local/src/drush 
-RUN cd /usr/local/src/drush && git checkout 9.1.0
+RUN cd /usr/local/src/drush && git checkout 10.3.6
 RUN ln -s /usr/local/src/drush/drush /usr/bin/drush
 RUN cd /usr/local/src/drush && composer update && composer install
 RUN cd /usr/src && curl https://drupalconsole.com/installer -L -o drupal.phar && mv drupal.phar /usr/local/bin/drupal
@@ -130,6 +131,15 @@ RUN cd /usr/src && curl https://drupalconsole.com/installer -L -o drupal.phar &&
 RUN cd /usr/src && wget https://github.com/openpreserve/fido/archive/v1.4.0.zip && unzip v1.4.0.zip \
 		&& ln -s /usr/bin/python3 /usr/bin/python
 RUN cd /usr/src/fido-1.4.0 && ./setup.py install
+
+# Install WACZ
+
+RUN git clone https://github.com/webrecorder/wacz-format.git /usr/local/src/wacz
+RUN cd /usr/local/src/wacz/ && git checkout master
+RUN cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && ./setup.py install
+
+#Clean up sources
+RUN rm -rf /usr/local/src/*
 
 # Change to bash since our folks like bash
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
See #21 

bad, bad busy box

## Before
```SHELL
patch -d
patch: unrecognized option: d
BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.

Usage: patch [OPTIONS] [ORIGFILE [PATCHFILE]]

	-p N	Strip N leading components from file names
	-i DIFF	Read DIFF instead of stdin
	-R	Reverse patch
	-N	Ignore already applied patches
	-E	Remove output files if they become empty
	--dry-run	Don't actually change files
```
## After
```SHELL
patch -d
patch: option requires an argument -- 'd'
patch: Try 'patch --help' for more information.
```

Good. This solves:

```
 Applying patches for drupal/search_api
    patches/1.18-3178941-metrocustom-referenced_entities_reindexing_fatal_error-D8.patch (Fix Content Entity Tracker in 1.18)
patch '-p1' --no-backup-if-mismatch -d 'web/modules/contrib/search_api' < '/var/www/html/patches/1.18-3178941-metrocustom-referenced_entities_reindexing_fatal_error-D8.patch'
patch: unrecognized option: d

BusyBox v1.30.1 (2019-06-12 17:51:55 UTC) multi-call binary.

Usage: patch [OPTIONS] [ORIGFILE [PATCHFILE]]

	-p N	Strip N leading components from file names
	-i DIFF	Read DIFF instead of stdin
	-R	Reverse patch
	-N	Ignore already applied patches
	-E	Remove output files if they become empty
	--dry-run	Don't actually change files

````
