### PR TITLE
ISSUE-28:Upgrade Cantaloupe to 5.0.4

### DIFF
--- a/esmero-cantaloupe/Dockerfile
+++ b/esmero-cantaloupe/Dockerfile
@@ -65,19 +65,14 @@ ENV JAVA_HOME=/opt/java/openjdk \
 # $ docker push esmero/cantaloupe-s3:4.1.9
 # If moving from Archipelago beta1 to beta3, see upgrading from 4.0.3 to 4.1.7 https://github.com/cantaloupe-project/cantaloupe/blob/develop/UPGRADING.md#40x--41
 
-ENV CANTALOUPE_VERSION 4.1.10
-ENV PKGNAME=graphicsmagick
-# 1.3.35 (Released Febr 23, 2020)
-ENV PKGVER=1.3.35
-# Uses 50% of the memory of 16. Use 16 if dealing with 48/64 bit pixels color
-ENV QUANTUMDEPTH=8
-ENV PKGSOURCE=http://downloads.sourceforge.net/$PKGNAME/$PKGNAME/$PKGVER/GraphicsMagick-$PKGVER.tar.lz
+ENV CANTALOUPE_VERSION 5.0.4
 
 EXPOSE 8182
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ffmpeg \
 		wget \
+                nasm \
   	        libopenjp2-tools \
                 libopenjp2-7-dev \
                 liblcms2-dev \
@@ -85,7 +80,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 libzstd-dev \
                 libtiff-dev \
                 libjpeg-dev \
-                libcairo2-dev libjpeg62-turbo-dev libpango1.0-dev libgif-dev build-essential \
+                libcairo2-dev libpango1.0-dev libgif-dev build-essential \
                 zlib1g-dev \
                 libwebp-dev \
                 libimage-exiftool-perl \
@@ -99,35 +94,39 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 zlib1g zlib1g-dev libxml2 libxml2-dev libltdl-dev libpng-dev libtool libopenjp2-7 libtiff-dev cmake automake autoconf make gcc g++ libimage-exiftool-perl  libfreetype6-dev \
                 && rm -rf /var/lib/apt/lists/*
 
-# Install TurboJpegProcessor dependencies
-RUN mkdir -p /opt/libjpeg-turbo/lib
+# Install TurboJpegProcessor
+WORKDIR /tmp
+RUN curl -OL https://sourceforge.net/projects/libjpeg-turbo/files/2.0.1/libjpeg-turbo-2.0.1.tar.gz \
+  && tar xzvf libjpeg-turbo-2.0.1.tar.gz \
+  && cd libjpeg-turbo-2.0.1 \
+  && mkdir BUILD && cd BUILD \
+  && cmake -DCMAKE_INSTALL_PREFIX=/usr    \
+      -DWITH_JAVA=1 \
+      -DCMAKE_BUILD_TYPE=Release     \
+      -DENABLE_STATIC=FALSE       \
+      -DCMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-2.0.1 \
+      -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib  \
+      ..  \
+  && make \
+  && make test \
+  && make install
 
-# Graphicsmagick dependencies
-#RUN apk add --no-cache --update g++ \
-#                     gcc \
-#                     make \
-#                     automake \
-#                     autoconf \
-#                     git \
-#                     lzip \
-#                     wget \
-#                     sdl-dev \
-#                     giflib-dev \
-#                     libjpeg-turbo-dev \
-#                     lcms2-dev \
-#                     libwmf-dev \
-#                     jasper-dev \
-#                     libx11-dev \
-#                     libpng-dev \
-#                     libtool \
-#                     jasper-dev \
-#                     bzip2-dev \
-#                     zlib-dev \
-#                     libxml2-dev \
-#                     tiff-dev \
-#                     exiftool \
-#                     freetype-dev \
-#                     libgomp 
+# Install GrokIMageCompression
+
+#WORKDIR /tmp
+#
+#RUN curl -OL https://github.com/GrokImageCompression/grok/archive/refs/tags/v9.2.0.tar.gz \
+#  && tar xzvf v9.2.0.tar.gz \
+#  && cd grok-9.2.0 \
+#  && mkdir BUILD && cd BUILD \
+#  && cmake -DCMAKE_INSTALL_PREFIX=/usr    \
+#      -DCMAKE_BUILD_TYPE=Release     \
+#      -DCMAKE_INSTALL_DOCDIR=/usr/share/doc/grok-9.2.0 \
+#      -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib  \
+#      ..  \
+#  && make \
+#  && make test \
+#  && make install
 
 WORKDIR /tmp
 
@@ -145,56 +144,22 @@ RUN curl -OL https://github.com/jasper-software/jasper/archive/version-2.0.32/ja
   && make test \
   && make install
 
-WORKDIR /tmp
-RUN wget $PKGSOURCE && \
-    lzip -d -c GraphicsMagick-$PKGVER.tar.lz | tar -xvf - && \
-    cd GraphicsMagick-$PKGVER && \
-    ./configure \
-      --build=$CBUILD \
-      --host=$CHOST \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --enable-magick-compat \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --enable-shared \
-      --disable-static \
-      --with-modules \
-      --with-threads \
-      --with-webp=yes \
-      --with-tiff=yes \
-      --with-jpeg=yes \
-      --with-jp2=yes \
-      --with-png=yes \
-      --with-xml=yes \
-      --with-wmf=yes \
-      --with-ttf \
-      --with-gs-font-dir=/usr/share/fonts/Type1 \
-      --with-quantum-depth=$QUANTUMDEPTH && \
-    make && \
-    make install && \
-    cd /tmp && \
-    rm -rf GraphicsMagick-$PKGVER && \
-    rm GraphicsMagick-$PKGVER.tar.lz
-  
-
 # Cantaloupe
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends maven unzip
 
-RUN curl -OL https://github.com/cantaloupe-project/cantaloupe/archive/refs/heads/release/4.1.zip \
+RUN curl -OL https://github.com/cantaloupe-project/cantaloupe/archive/refs/heads/release/5.0.zip \
  && mkdir -p /usr/local/ \
  && cd /usr/local \
- && unzip /tmp/4.1.zip && cd cantaloupe-release-4.1 && mvn clean package -DskipTests \ 
- && mv target/cantaloupe-4.1.10-SNAPSHOT.zip /usr/local/ \
+ && unzip /tmp/5.0.zip && cd cantaloupe-release-5.0 && mvn clean package -DskipTests \ 
+ && mv target/cantaloupe-5.0.4.zip /usr/local/ \
  && cd /usr/local \
- && unzip cantaloupe-4.1.10-SNAPSHOT.zip \
- && ln -s cantaloupe-4.1.10-SNAPSHOT cantaloupe \
- && rm -rf /tmp/4.1.zip \
- && rm -rf /usr/local/cantaloupe-4.1.10-SNAPSHOT.zip \
- && rm -rf /usr/local/cantaloupe-release-4.1 \
+ && unzip cantaloupe-5.0.4.zip \
+ && ln -s cantaloupe-5.0.4 cantaloupe \
+ && rm -rf /tmp/5.0.zip \
+ && rm -rf /usr/local/cantaloupe-release-5.0.zip \
+ && rm -rf /usr/local/cantaloupe-release-5.0 \
  && ls /usr/local/cantaloupe/cantaloupe-* \
  && mkdir -p /etc/cantaloupe
 
@@ -224,5 +189,5 @@ USER $user
 
 
 VOLUME ["/var/log/cantaloupe", "/var/cache/cantaloupe"]
-CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe/cantaloupe.properties -Xms${XMS} -Xmx${XMX} -jar /usr/local/cantaloupe/cantaloupe-4.1.10-SNAPSHOT.war"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe/cantaloupe.properties -Xms${XMS} -Xmx${XMX} -jar /usr/local/cantaloupe/cantaloupe-5.0.4.jar"]
 

--- a/esmero-cantaloupe/Dockerfile
+++ b/esmero-cantaloupe/Dockerfile
@@ -109,24 +109,9 @@ RUN curl -OL https://sourceforge.net/projects/libjpeg-turbo/files/2.0.1/libjpeg-
       ..  \
   && make \
   && make test \
-  && make install
-
-# Install GrokIMageCompression
-
-#WORKDIR /tmp
-#
-#RUN curl -OL https://github.com/GrokImageCompression/grok/archive/refs/tags/v9.2.0.tar.gz \
-#  && tar xzvf v9.2.0.tar.gz \
-#  && cd grok-9.2.0 \
-#  && mkdir BUILD && cd BUILD \
-#  && cmake -DCMAKE_INSTALL_PREFIX=/usr    \
-#      -DCMAKE_BUILD_TYPE=Release     \
-#      -DCMAKE_INSTALL_DOCDIR=/usr/share/doc/grok-9.2.0 \
-#      -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib  \
-#      ..  \
-#  && make \
-#  && make test \
-#  && make install
+  && make install \
+  && rm -rf /tmp/libjpeg-turbo-2.0.1.tar.gz \
+  && rm -rf /tmp/libjpeg-turbo-2.0.1
 
 WORKDIR /tmp
 
@@ -142,31 +127,31 @@ RUN curl -OL https://github.com/jasper-software/jasper/archive/version-2.0.32/ja
       ..  \
   && make \
   && make test \
-  && make install
+  && make install \
+  && rm -rf /tmp/jasper-2.0.32.tar.gz \
+  && rm -r /tmp/jasper-version-2.0.32
 
 # Cantaloupe
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends maven unzip
 
-RUN curl -OL https://github.com/cantaloupe-project/cantaloupe/archive/refs/heads/release/5.0.zip \
+RUN curl -OL https://github.com/cantaloupe-project/cantaloupe/archive/refs/tags/v${CANTALOUPE_VERSION}.zip \
  && mkdir -p /usr/local/ \
+ && unzip /tmp/v${CANTALOUPE_VERSION}.zip && cd cantaloupe-${CANTALOUPE_VERSION} && mvn clean package -DskipTests \ 
+ && mv target/cantaloupe-${CANTALOUPE_VERSION}.zip /usr/local/ \
  && cd /usr/local \
- && unzip /tmp/5.0.zip && cd cantaloupe-release-5.0 && mvn clean package -DskipTests \ 
- && mv target/cantaloupe-5.0.4.zip /usr/local/ \
- && cd /usr/local \
- && unzip cantaloupe-5.0.4.zip \
- && ln -s cantaloupe-5.0.4 cantaloupe \
- && rm -rf /tmp/5.0.zip \
- && rm -rf /usr/local/cantaloupe-release-5.0.zip \
- && rm -rf /usr/local/cantaloupe-release-5.0 \
+ && unzip cantaloupe-${CANTALOUPE_VERSION}.zip \
+ && ln -s cantaloupe-${CANTALOUPE_VERSION} cantaloupe \
+ && rm -rf /tmp/v${CANTALOUPE_VERSION}.zip \
+ && rm -rf /usr/local/cantaloupe-${CANTALOUPE_VERSION}.zip \
  && ls /usr/local/cantaloupe/cantaloupe-* \
  && mkdir -p /etc/cantaloupe
 
 
 ARG user=cantaloupe
 ARG home=/home/$user
-RUN adduser --home $home $user
+RUN adduser -u 8183 --home $home $user
 RUN chown -R $user $home
 
 # upcoming docker releases: use --chown=cantaloupe
@@ -189,5 +174,5 @@ USER $user
 
 
 VOLUME ["/var/log/cantaloupe", "/var/cache/cantaloupe"]
-CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe/cantaloupe.properties -Xms${XMS} -Xmx${XMX} -jar /usr/local/cantaloupe/cantaloupe-5.0.4.jar"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe/cantaloupe.properties -Xms${XMS} -Xmx${XMX} -jar /usr/local/cantaloupe/cantaloupe-${CANTALOUPE_VERSION}.jar"]
 

--- a/esmero-cantaloupe/cantaloupe.properties
+++ b/esmero-cantaloupe/cantaloupe.properties
@@ -247,14 +247,13 @@ processor.selection_strategy = ManualSelectionStrategy
 
 
 # Image processors to use for various source formats. Available values are
-# `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
-# `KakaduDemoProcessor`, `KakaduNativeProcessor`, `OpenJpegProcessor`,
-# `JaiProcessor`, `PdfBoxProcessor`, and `FfmpegProcessor`.
+# `Java2dProcessor`, `KakaduDemoProcessor`, `KakaduNativeProcessor`, `OpenJpegProcessor`,
+# `TurgoJpegProcessor`, `JaiProcessor`, `PdfBoxProcessor`, and `FfmpegProcessor`.
 
 # These extension-specific definitions are optional.
 processor.ManualSelectionStrategy.avi = FfmpegProcessor
 processor.ManualSelectionStrategy.bmp =
-processor.ManualSelectionStrategy.dcm = GraphicsMagickProcessor
+processor.ManualSelectionStrategy.dcm = 
 processor.ManualSelectionStrategy.flv = FfmpegProcessor
 processor.ManualSelectionStrategy.gif =
 processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
@@ -266,6 +265,11 @@ processor.ManualSelectionStrategy.pdf = PdfBoxProcessor
 processor.ManualSelectionStrategy.png = Java2dProcessor
 processor.ManualSelectionStrategy.tif = Java2dProcessor
 processor.ManualSelectionStrategy.webm = FfmpegProcessor
+processor.ManualSelectionStrategy.xpm = Java2dProcessor
+
+# webp is not currently supported in this release but may return in the next major release per https://github.com/cantaloupe-project/cantaloupe/issues/470
+#processor.ManualSelectionStrategy.webp=
+#processor.webp =
 
 # Fall back to this processor for any formats not assigned above.
 processor.ManualSelectionStrategy.fallback = Java2dProcessor
@@ -348,22 +352,6 @@ processor.imageio.tif.writer =
 # Optional absolute path of the directory containing the FFmpeg binaries.
 # Overrides the PATH.
 FfmpegProcessor.path_to_binaries = /usr/bin
-
-#----------------------------------------
-# GraphicsMagickProcessor
-#----------------------------------------
-
-# !! Optional absolute path of the directory containing the GraphicsMagick
-# binary. Overrides the PATH.
-GraphicsMagickProcessor.path_to_binaries = /usr/bin
-
-#----------------------------------------
-# ImageMagickProcessor
-#----------------------------------------
-
-# !! Optional absolute path of the directory containing the ImageMagick
-# binary. Overrides the PATH.
-ImageMagickProcessor.path_to_binaries =
 
 #----------------------------------------
 # KakaduDemoProcessor
@@ -695,5 +683,3 @@ log.access.SyslogAppender.enabled = false
 log.access.SyslogAppender.host =
 log.access.SyslogAppender.port = 514
 log.access.SyslogAppender.facility = LOCAL0
-processor.webp =
-processor.ManualSelectionStrategy.webp=


### PR DESCRIPTION
Upgrade Cantaloupe to 5.0.4 as described [here](https://github.com/esmero/archipelago-docker-images/issues/28). One part of this PR not included in the issue is the installation of [TurboJpegProcessor](https://cantaloupe-project.github.io/manual/5.0/processors.html#TurboJpegProcessor), which should adds a performance boost for JPEG reading/writing, as described in the docs. GraphicsMagick/ImageMagick has also been removed since it's no longer supported (see issue).

Resolves #28 