### PR TITLE
ISSUE-33: PHP8 multi architecture and improvements on NPL

### DIFF
--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -1,22 +1,46 @@
-# from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.4-fpm-alpine
+# from https://www.drupal.org/docs/9/system-requirements/drupal-9-php-requirements
+FROM php:8.0.16-fpm-alpine3.15
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+
+# FONTS?
+
+RUN apk --no-cache add msttcorefonts-installer fontconfig && \
+    update-ms-fonts && \
+    fc-cache -f
+    
+# For now not going pdftotree    
+#RUN set -eux; \
+#    \
+#    apk add --update python3-dev \
+#		 py3-pip \
+#         linux-headers \
+#         musl-dev \
+#         build-base \
+#         hdf5 \
+#         hdf5-dev \
+#         py3-pip py3-numpy py3-pandas py3-scipy py3-scikit-learn py3-wheel py3-pillow jpeg-dev zlib-dev
+#RUN set -eux; pip install --no-cache-dir --no-binary :all: tables h5py 
+#RUN set -eux; pip install pdftotree
+        
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		coreutils \
-                zlib-dev \
+        zlib-dev \
 		libxml2-dev \
 		libxslt-dev \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+                # zlib \
 		libzip-dev \
 		postgresql-dev \
-		php7-dev \
+		php8-dev \
 		# Equivalent of build essentials
 		alpine-sdk \
+        pcre-dev \
+        $PHPIZE_DEPS \
 		imagemagick \
 		imagemagick-libs \
 		imagemagick-dev \
@@ -49,11 +73,13 @@ RUN set -eux; \
 	)"; \
 	pecl install imagick; \
         pecl install apcu; \
+        pecl install redis; \
 	\
 	apk add --virtual .drupal-phpexts-rundeps $runDeps; \
 	docker-php-ext-enable imagick; \
         docker-php-ext-enable apcu; \
         docker-php-ext-enable pcntl; \
+        docker-php-ext-enable redis.so; \
         apk del .build-deps
 
 # set recommended PHP.ini settings
@@ -74,7 +100,7 @@ RUN { \
 		echo 'max_execution_time = 300'; \
 		echo 'log_errors = On'; \
 		echo 'error_log = /proc/self/fd/2'; \
-	} > /usr/local/etc/php/conf.d/archipelagod8-recommended.ini
+	} > /usr/local/etc/php/conf.d/archipelagod9-recommended.ini
 
 RUN { \
 		echo 'php_admin_value[error_log] = /proc/self/fd/2'; \
@@ -92,7 +118,7 @@ RUN { \
 		echo 'error_log = /proc/self/fd/2'; \
 	} > /usr/local/etc/php/php-cli.ini
 	
-
+    
 # Tools we want to keep
 RUN apk -U add --no-cache \
 		bash \
@@ -104,39 +130,133 @@ RUN apk -U add --no-cache \
 		file \
 		curl \
 		nano \
+        libxml2 \
 		ghostscript \
 		poppler-utils \
 		python3 \
-		tesseract-ocr \
+        xpdf \
+        freetype \
+        icu-libs \
 		tesseract-ocr-data-ita \
 		tesseract-ocr-data-spa \
-                tesseract-ocr-data-deu \
-                tesseract-ocr-data-tam \
-                tesseract-ocr-data-por \
-                mediainfo \
+        tesseract-ocr-data-deu \
+        tesseract-ocr-data-tam \
+        tesseract-ocr-data-por \
+        tesseract-ocr-data-hin \
+        mediainfo \
 		exiftool \
 		py3-setuptools \
+        py-pip \
 		&& \
 		rm -rf /var/lib/apt/lists/* && \
 		rm /var/cache/apk/*
 
+WORKDIR /usr/local/src
+
+# Detect architecture for Tesseract 5
+RUN set -eux; \
+ARCH="$(uname -m)"; \
+case "${ARCH}" in \
+   aarch64|arm64) \
+     musl='aarch64-alpine-linux-musl'; \
+     ;; \
+   amd64|x86_64) \
+     musl='x86_64-alpine-linux-musl'; \
+     ;; \
+   *) \
+     echo "Unsupported arch: ${ARCH}"; \
+     exit 1; \
+     ;; \
+esac;
+
+# Build Tesseract 5
+RUN apk update && apk add --no-cache --virtual .build-deps-tesseract \
+       gcc \
+       g++ \
+       make \
+       automake \
+       autoconf \
+       musl \
+       libc-dev \
+       libtool \
+       alpine-sdk \
+       pkgconfig \
+       clang \
+       clang-dev \
+       libtool \
+       leptonica-dev \
+       openjpeg-dev \
+       tiff-dev \
+       libpng-dev \
+       zlib-dev \
+       libgcc \
+       mupdf-dev \
+       jbig2dec-dev \
+       freetype-dev \
+       openblas-dev \
+       ffmpeg-dev \
+       icu-dev \
+       git \
+       linux-headers && \
+       git clone --depth 1 https://github.com/danbloomberg/leptonica.git && cd leptonica && ./autogen.sh && ./configure --build=${musl} --host=${musl} && make && make install && cd ..;\
+       git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh; \
+   ./configure --build=${musl} --host=${musl} ;\
+   make && make install && ldconfig ;\
+   apk del .build-deps-tesseract;
+
+RUN pwd; uname -a;
+
+# Build PDF Alto
+WORKDIR /usr/src
+RUN git clone --depth 1 https://github.com/diegopino/pdfalto.git -b alpine
+RUN git clone https://github.com/diegopino/xpdf-4.03.git -b alpine && cp -rpv xpdf-4.03 /usr/src/pdfalto/.
+
+WORKDIR /usr/src/pdfalto
+RUN set -eux; \
+\
+apk update && apk add --no-cache --virtual .build-deps-pdfalto \
+     git \
+     cmake \
+     make \
+     musl \
+     musl-dev \
+     g++ gcc clang clang-dev clang-extra-tools clang-libs \
+     libpng-dev \
+     icu-libs \
+     icu-dev \
+     libgcc \
+     tiff-dev \
+     freetype-dev \
+     libc-dev \
+     linux-headers \
+     libxml2-dev \
+     glib \
+     pkgconfig \
+     glib-dev && \
+     cd /usr/src/pdfalto/libs/image/png/src && cmake "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true" . && make && \
+     cp /usr/src/pdfalto/libs/image/png/src/libpng.a /usr/src/pdfalto/libs/image/png/linux/64/ && \
+     cd /usr/src/pdfalto && cmake . && make && make install && cp pdfalto /usr/bin/pdfalto; \
+     apk del .build-deps-pdfalto;
+    
+
 RUN apk add gnu-libiconv --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
+WORKDIR /usr/src/
 # Installation of Composer
 RUN cd /usr/src && curl -sS http://getcomposer.org/installer | php
 RUN cd /usr/src && mv composer.phar /usr/bin/composer && composer self-update && composer self-update --2
 
 # Installation of drush
 RUN git clone https://github.com/drush-ops/drush.git /usr/local/src/drush 
-RUN cd /usr/local/src/drush && git checkout 10.3.6
+RUN cd /usr/local/src/drush && git checkout 11.0.5
 RUN ln -s /usr/local/src/drush/drush /usr/bin/drush
 RUN cd /usr/local/src/drush && composer update && composer install
 
 # Install Fido 
-RUN cd /usr/src && wget https://github.com/openpreserve/fido/archive/v1.4.0.zip && unzip v1.4.0.zip \
-		&& ln -s /usr/bin/python3 /usr/bin/python
-RUN cd /usr/src/fido-1.4.0 && ./setup.py install
+RUN cd /usr/src && wget https://github.com/openpreserve/fido/archive/v1.4.1.zip && unzip v1.4.1.zip \
+		&& ln -s /usr/bin/python3 /usr/bin/python && pip install wheel
+RUN cd /usr/src/fido-1.4.1 && ./setup.py install
 
 # Install WACZ
 RUN set -eux; \
@@ -147,12 +267,15 @@ RUN set -eux; \
                  linux-headers \
                  musl-dev \
                  && \
-		 git clone https://github.com/webrecorder/wacz-format.git /usr/local/src/wacz && \
+		 git clone https://github.com/webrecorder/py-wacz /usr/local/src/wacz && \
                  cd /usr/local/src/wacz/ && git checkout main && \
-                 cd /usr/local/src/wacz/py-wacz && pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install
+                 pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install
 
 #Clean up sources, we need to keep drush one
 RUN rm -rf /usr/local/src/wacz
+RUN rm -rf /usr/local/src/tesseract
+RUN rm -rf /usr/src/pdfalto
+RUN rm -rf /usr/src/xpdf
 
 # Change to bash since our folks like bash
 SHELL ["/bin/bash", "-c"]

--- a/esmero-php-fpm/Dockerfile.dev
+++ b/esmero-php-fpm/Dockerfile.dev
@@ -1,8 +1,8 @@
 # build with:
-# sudo docker build -f Dockerfile.dev -t esmero/php-7.4-fpm:1.0.0-dev-multiarch . --no-cache
+# sudo docker build -f Dockerfile.dev -t esmero/php-8.0-fpm:1.0.0-dev-multiarch . --no-cache
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 
-FROM esmero/php-7.4-fpm:1.0.0-RC2-multiarch
+FROM esmero/php-8.0-fpm:1.0.0-multiarch
 
 # install the extensions we need for xdebug install
 RUN set -eux; \

--- a/esmero-php-fpm/README.md
+++ b/esmero-php-fpm/README.md
@@ -1,10 +1,10 @@
-##  Esmero-php FPM 7.4.9 Container
+##  Esmero-php FPM 8.0.16 Container
 
-A ready to be used with Archipelago in a docker-compose file with NGINX . Runs a standard PHP 7.4.9 FPM Container with some embeded extras.
+A ready to be used with Archipelago in a docker-compose file with NGINX. Runs a standard PHP 8.0.16 FPM Container with embeded extras.
 
 ### Building the image
 ```SHELL
-$ docker build -t esmero/php-7.4-fpm:1.0.0-RC1 .
+$ docker build -t esmero/php-8.0-fpm:1.0.0 .
 ````
 
 ### Configuration and startup
@@ -13,8 +13,19 @@ Use with an NGINX Container using fastcgi proxying against this container
 
 ### Deployed features
 
-PHP 7.4 with OPCACHE and D8/D9 Optimizations
-TESSERACT
-COMPOSER
-DRUSH
-BASH (yes)
+- PHP 8.0.16 with redis extension and D9 Optimizations
+- TESSERACT 5.1 with JP2 support and OpenMP (/usr/local/bin/tesseract)
+- TESSERACT 4.x with JP2 support and SSE (/usr/bin/tesseract)
+- COMPOSER
+- DRUSH
+- BASH (yes)
+- PDFALTO 0.5
+- FIDO 1.4 
+- Webfonts
+
+#### Multiplaform Build
+
+docker buildx create --name m1_builder
+docker buildx use m1_builder
+docker buildx inspect --bootstrap
+docker buildx build --platform linux/amd64,linux/arm64 -t esmero/php-8.0-fpm:1.0.0-multiarch . --push

--- a/nlpserver/Dockerfile
+++ b/nlpserver/Dockerfile
@@ -1,7 +1,11 @@
 # From https://hub.docker.com/_/python 
 # using slim buster because docs say alpine makes python building slower
 
-FROM python:3.8.6-slim-buster
+FROM python:3.10.1-slim-buster
+
+# Use the Architecture to decide on pycld
+ARG TARGETPLATFORM
+
 
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -14,20 +18,36 @@ RUN rm "v1.0.1.tar.gz" && mv nlpserver-1.0.1 nlpserver
 WORKDIR /usr/src/nlpserver
 
 RUN apt-get -y install pkg-config && \
-    apt-get install build-essential software-properties-common -y 
-RUN apt-get -y install -y python-dev python-numpy python3-dev libevent-dev libicu-dev && \
-    apt-get -y install -y python3-pip && \
-    python3 -m pip install --no-cache-dir --default-timeout=100 -r requirements.txt
+    apt-get install build-essential git software-properties-common -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update &&  apt-get -y install -y python-dev python-numpy python3-dev libevent-dev libicu-dev && \
+    apt-get -y install -y python3-pip && rm -rf /var/lib/apt/lists/* 
+# We can't use requirements.txt because of custom ARM64 pycld2
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 newspaper3k
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then BRANCH=master; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then BRANCH=aarch64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then BRANCH=aarch64; else BRANCH=master; fi \
+  && python3 -m pip install --no-cache-dir --default-timeout=100 -e git+git://github.com/DiegoPino/pycld2.git@${BRANCH}#egg=pycld2
+# RUN python3 -m pip install --no-cache-dir --default-timeout=100 -e git+git://github.com/DiegoPino/pycld2.git@aarch64#egg=pycld2
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 gensim 
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 pyicu numpy Flask morfessor langid BeautifulSoup4 afinn textblob
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 spacy
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 polyglot
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 readability-lxml
+
 # English, spanish and Italian
 # TODO add this as built time arguments
-RUN polyglot download LANG:en
-RUN polyglot download LANG:es
-RUN polyglot download LANG:it
+RUN polyglot download LANG:en && \
+    polyglot download LANG:es && \
+    polyglot download LANG:it && \
+    polyglot download LANG:pt && \
+    polyglot download LANG:de && \
+    polyglot download LANG:hi
+
 
 RUN python3 -m spacy download en && \
     python3 -m spacy download xx && \
     python3 -m spacy download es && \
-    python3 -m spacy download it
+    python3 -m spacy download pt && \
+    python3 -m spacy download de && \
+    python3 -m spacy download it 
 
  # Supervisor
 COPY nlpserver.conf /etc/supervisor/conf.d


### PR DESCRIPTION
# What?

See #33 

This pull includes the sources for published the following published Containers to docker hub
- esmero/php-8.0-fpm:1.0.0-multiarch
- esmero/php-8.0-fpm:1.0.0-dev-multiarch

and an Updated README.md

Includes:
- 2x Tesseracts with JP2 support
- Redis PhpRedis PHP Extension
- PHP 8.0.16 on newer Alpine
- pdfalto build on each platform using dynamic libraries but statically linked

This pull also includes an improved NPL Container Source with my own Patches


