### PR TITLE
Update nlpserver Dockerfile to retrieve pycld2 via https://

### DIFF
--- a/nlpserver/Dockerfile
+++ b/nlpserver/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update &&  apt-get -y install -y python-dev python-numpy python3-dev
 # We can't use requirements.txt because of custom ARM64 pycld2
 RUN python3 -m pip install --no-cache-dir --default-timeout=100 newspaper3k
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then BRANCH=master; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then BRANCH=aarch64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then BRANCH=aarch64; else BRANCH=master; fi \
-  && python3 -m pip install --no-cache-dir --default-timeout=100 -e git+git://github.com/DiegoPino/pycld2.git@${BRANCH}#egg=pycld2
+  && python3 -m pip install --no-cache-dir --default-timeout=100 -e git+https://github.com/DiegoPino/pycld2.git@${BRANCH}#egg=pycld2
 # RUN python3 -m pip install --no-cache-dir --default-timeout=100 -e git+git://github.com/DiegoPino/pycld2.git@aarch64#egg=pycld2
 RUN python3 -m pip install --no-cache-dir --default-timeout=100 gensim 
 RUN python3 -m pip install --no-cache-dir --default-timeout=100 pyicu numpy Flask morfessor langid BeautifulSoup4 afinn textblob


### PR DESCRIPTION
GitHub turned off support for the git:// protocol on March 15th 2022 (see https://github.blog/2021-09-01-improving-git-protocol-security-github/) and this prevented the `nlpserver` container from building, as it relied on retrieving Diego's fork of pycld2 via a git:// URL.

This PR simply updates that URL to use https:// instead, as recommended by GitHub for anonymous clone commands, and thus allows the container to build again.

Tested on Linux Mint 20.2 with Docker 20.10.14 (build a224086) running on an Intel Core i5. I'm afraid I don't have access to an ARM machine for testing, but I can't see any reason for this change not to work against that architecture.
