### PR TITLE
ISSUE-56: Update PHP image to 8.028

### DIFF
--- a/esmero-php-fpm/Dockerfile
+++ b/esmero-php-fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/9/system-requirements/drupal-9-php-requirements
-FROM php:8.0.24-fpm-alpine3.15
+FROM php:8.0.28-fpm-alpine3.16
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 
@@ -274,7 +274,8 @@ RUN set -eux; \
                  && \
 		 git clone https://github.com/webrecorder/py-wacz /usr/local/src/wacz && \
                  cd /usr/local/src/wacz/ && git checkout main && \
-                 pip3 install -r requirements.txt && chmod 755 setup.py && ./setup.py install
+                 pip3 install --upgrade setuptools && \
+                 pip3 install -r requirements.txt --ignore-installed packaging && chmod 755 setup.py && ./setup.py install
 
 # Build Image Magick with JP2 Support
 RUN set -eux; \

--- a/esmero-php-fpm/Dockerfile.dev
+++ b/esmero-php-fpm/Dockerfile.dev
@@ -1,8 +1,8 @@
 # build with:
-# sudo docker build -f Dockerfile.dev -t esmero/php-8.0.24-fpm:1.0.0-dev-multiarch . --no-cache
+# sudo docker build -f Dockerfile.dev -t esmero/php-8.0.28-fpm:1.1.0-dev-multiarch . --no-cache
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 
-FROM esmero/php-8.0.24-fpm:1.1.0-multiarch
+FROM esmero/php-8.0.28-fpm:1.1.0-multiarch
 
 # install the extensions we need for xdebug install
 RUN set -eux; \

--- a/esmero-php-fpm/README.md
+++ b/esmero-php-fpm/README.md
@@ -1,11 +1,12 @@
-##  Esmero-php FPM 8.0.16 Container
+##  Esmero-php FPM 8.0.28 Container
 
-A ready to be used with Archipelago in a docker-compose file with NGINX. Runs a standard PHP 8.0.16 FPM Container with embeded extras.
+A ready to be used with Archipelago in a docker-compose file with NGINX. Runs a standard PHP 8.0.28 FPM Container with embeded extras.
 
 ### Building the image
-```SHELL
-$ docker build -t esmero/php-8.0-fpm:1.0.0 .
-````
+
+```docker
+docker build -t esmero/php-8.0.28-fpm:1.1.0 .
+```
 
 ### Configuration and startup
 
@@ -13,7 +14,7 @@ Use with an NGINX Container using fastcgi proxying against this container
 
 ### Deployed features
 
-- PHP 8.0.16 with redis extension and D9 Optimizations
+- PHP 8.0.28 with redis extension and D9 Optimizations
 - TESSERACT 5.1 with JP2 support and OpenMP (/usr/local/bin/tesseract)
 - TESSERACT 4.x with JP2 support and SSE (/usr/bin/tesseract)
 - COMPOSER
@@ -23,9 +24,20 @@ Use with an NGINX Container using fastcgi proxying against this container
 - FIDO 1.4 
 - Webfonts
 
-#### Multiplaform Build
+#### Multiplatform Build
 
+For reference on `docker buildx` usage see [Docker's Multi-platform images documentation](https://docs.docker.com/build/building/multi-platform/).
+
+```docker
 docker buildx create --name m1_builder
 docker buildx use m1_builder
 docker buildx inspect --bootstrap
-docker buildx build --platform linux/amd64,linux/arm64 -t esmero/php-8.0-fpm:1.0.0-multiarch . --push
+docker buildx build --platform linux/amd64,linux/arm64 -t esmero/php-8.0.28-fpm:1.1.0-multiarch . --push
+```
+
+To build the debug image for developing, after building and pushing the image above to your repo, update the base image in `Dockerfile.dev` and run the following:
+
+```docker
+docker buildx build --platform linux/amd64,linux/arm64 -t esmero/php-8.0.28-fpm:1.1.0-multiarch . --push --file Dockerfile.dev
+```
+


### PR DESCRIPTION
Resolves #56.

In addition to updating the base Alpine PHP image, which required moving from kernel 3.15 to 3.16, 2 small changes needed to made to the WACZ install's Python library steps:

* The `packaging` library needs to be ignored in the `requirements.txt` install because it produces an error otherwise (possibly due to it being a dependency for the `py3-setuptools` install as a system package earlier).
* Python's `setuptools` needs to be upgraded as mentioned [here](https://github.com/pypa/packaging-problems/issues/573#issuecomment-1144419849) because another error occurs in the same step above.